### PR TITLE
fix: detect cids in query parameters

### DIFF
--- a/src/sw/controller.js
+++ b/src/sw/controller.js
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import * as Sentry from '@sentry/browser'
 
 import { Interceptor } from './interceptor.js'
-import { findCIDInURL } from '../utils.js'
+import { findCIDPathInURL } from '../utils.js'
 
 const FILTERED_HOSTS = [
     'images.studio.metaplex.com',
@@ -48,11 +48,11 @@ export class Controller {
             }
 
             const { url } = event.request
-            const cid = findCIDInURL(url)
+            const cidPath = findCIDPathInURL(url)
 
-            if (cid) {
-                debug('cid', cid, url)
-                event.respondWith(fetchCID(cid, this.saturn, this.clientId, event))
+            if (cidPath) {
+                debug('cidPath', cidPath, url)
+                event.respondWith(fetchCID(cidPath, this.saturn, this.clientId, event))
             }
         })
     }
@@ -76,12 +76,12 @@ function getClientKey() {
     return clientKey
 }
 
-async function fetchCID (cid, saturn, clientId, event) {
+async function fetchCID(cidPath, saturn, clientId, event) {
     let response = null
     const { request } = event
 
     try {
-        const interceptor = new Interceptor(cid, saturn, clientId, event)
+        const interceptor = new Interceptor(cidPath, saturn, clientId, event)
         response = await interceptor.fetch()
     } catch (err) {
         debug(`${request.url}: fetchCID err %O`, err)

--- a/src/sw/interceptor.js
+++ b/src/sw/interceptor.js
@@ -2,8 +2,6 @@ import toIterable from 'browser-readablestream-to-it'
 import createDebug from 'debug'
 import * as Sentry from '@sentry/browser'
 
-import { getCidPathFromURL } from '../utils.js'
-
 const debug = createDebug('sw')
 const cl = console.log
 
@@ -11,9 +9,8 @@ export class Interceptor {
     static nocache = false // request/response skips L1 cache entirely
     static bypasscache = false // request skips L1 cache, response gets cached.
 
-    constructor(cid, saturn, clientId, event) {
-        this.cid = cid
-        this.cidPath = getCidPathFromURL(event.request.url, cid)
+    constructor(cidPath, saturn, clientId, event) {
+        this.cidPath = cidPath
         this.saturn = saturn
         this.clientId = clientId
         this.event = event

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,8 +66,8 @@ export function findCIDPathInURL(url) {
     const { hostname, pathname, searchParams, href } = urlObj
 
     const searchStrings = [
-        hostname + pathname,
-        ...searchParams.values()
+        hostname + pathname, // checks for path based or subdomain based cids.
+        ...searchParams.values(), // params could contain cid URLs, e.g. ?url=ipfs.io/ipfs/<cid>
     ]
 
     for (const str of searchStrings) {
@@ -89,9 +89,10 @@ function findCIDPathInUrlComponent(str) {
     let cid = null
     let path = null
 
-    const splitStr = str.split('/')
+    // Heuristic to check if the first segment is a domain.
     const isMaybeHost = splitStr[0].includes('.')
 
+    // Assumes the rest of the segments after the cid form the file path.
     const segmentsToPath = i => splitStr.slice(i).join('/') || null
 
     for (let i = 0; i < splitStr.length; i++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,6 +89,7 @@ function findCIDPathInUrlComponent(str) {
     let cid = null
     let path = null
 
+    const splitStr = str.replace(/https?:\/\//, '').split('/')
     // Heuristic to check if the first segment is a domain.
     const isMaybeHost = splitStr[0].includes('.')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,8 +60,8 @@ export function findCIDPathInURL(url) {
         return null
     }
 
-    let cid = ''
-    let path = ''
+    let cid = null
+    let path = null
 
     const { hostname, pathname, searchParams, href } = urlObj
 
@@ -86,13 +86,13 @@ export function findCIDPathInURL(url) {
 }
 
 function findCIDPathInUrlComponent(str) {
-    let cid = ''
-    let path = ''
+    let cid = null
+    let path = null
 
     const splitStr = str.split('/')
     const isMaybeHost = splitStr[0].includes('.')
 
-    const segmentsToPath = i => splitStr.slice(i).join('/') || ''
+    const segmentsToPath = i => splitStr.slice(i).join('/') || null
 
     for (let i = 0; i < splitStr.length; i++) {
         const segment = splitStr[i]

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,7 @@ function findCIDPathInUrlComponent(str) {
     const splitStr = str.split('/')
     const isMaybeHost = splitStr[0].includes('.')
 
-    const segmentsToPath = i => splitStr.slice(i).join('/') ?? ''
+    const segmentsToPath = i => splitStr.slice(i).join('/') || ''
 
     for (let i = 0; i < splitStr.length; i++) {
         const segment = splitStr[i]

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,31 +52,65 @@ export class Deferred {
 }
 
 // Modified from https://github.com/PinataCloud/ipfs-gateway-tools/blob/34533f3d5f3c0dd616327e2e5443072c27ea569d/src/index.js#L6
-export function findCIDInURL (url) {
-    const splitUrl = url.split('?')[0].split('/')
-    for (const split of splitUrl) {
-        if (isIPFS.cid(split)) {
-            return split
-        }
-        const splitOnDot = split.split('.')[0]
-        if(isIPFS.cid(splitOnDot)) {
-            return splitOnDot
+export function findCIDPathInURL(url) {
+    let urlObj
+    try {
+        urlObj = new URL(url)
+    } catch (err) {
+        return null
+    }
+
+    let cid = ''
+    let path = ''
+
+    const { hostname, pathname, searchParams, href } = urlObj
+
+    const searchStrings = [
+        hostname + pathname,
+        ...searchParams.values()
+    ]
+
+    for (const str of searchStrings) {
+        const result = findCIDPathInUrlComponent(str)
+
+        // sanity check if parsed cid appears in URL
+        if (result.cid && href.includes(result.cid)) {
+            ({ cid, path } = result)
+            break
         }
     }
 
-    return null
-}
-
-export function getCidPathFromURL(url, cid) {
-    const { hostname, pathname } = new URL(url)
-    let cidPath
-
-    if (pathname.startsWith('/ipfs/')) {
-        cidPath = pathname.replace('/ipfs/', '')
-    } else if (hostname.includes(cid)) {
-        // https://<cid>.ipfs.dweb.link/cat.png -> https://saturn.ms/ipfs/<cid>/cat.png
-        cidPath = cid + pathname
-    }
+    const cidPath = path ? `${cid}/${path}` : cid
 
     return cidPath
+}
+
+function findCIDPathInUrlComponent(str) {
+    let cid = ''
+    let path = ''
+
+    const splitStr = str.split('/')
+    const isMaybeHost = splitStr[0].includes('.')
+
+    const segmentsToPath = i => splitStr.slice(i).join('/') ?? ''
+
+    for (let i = 0; i < splitStr.length; i++) {
+        const segment = splitStr[i]
+        if (isIPFS.cid(segment)) {
+            cid = segment
+            path = segmentsToPath(i + 1)
+            break
+        }
+
+        const splitOnDot = segment.split('.')[0]
+        if(isIPFS.cid(splitOnDot)) {
+            cid = splitOnDot
+            if (isMaybeHost) {
+                path = segmentsToPath(1)
+            }
+            break
+        }
+    }
+
+    return { cid, path }
 }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -79,9 +79,9 @@ describe('controller', () => {
         assert.strictEqual(findCIDPathInURL(url), cidPath)
     })
 
-    it('returns empty string if cid not found', () => {
+    it('returns null if cid not found', () => {
         const url = 'https://example.com/hello/world.png'
 
-        assert.strictEqual(findCIDPathInURL(url), '')
+        assert.strictEqual(findCIDPathInURL(url), null)
     })
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -59,7 +59,7 @@ describe('controller', () => {
         const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
         const path = 'dog/cow/cat.png'
         const cidPath = `${cid}/${path}`
-        const param = `${cid}.ipfs.dweb.link/${path}`
+        const param = `https%3A%2F%2F${cid}.ipfs.dweb.link/${path}`
         const url = `https://proxy.com/?url=${param}`
 
         assert.strictEqual(findCIDPathInURL(url), cidPath)

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -19,14 +19,6 @@ describe('controller', () => {
         assert.strictEqual(findCIDPathInURL(url), cidPath)
     })
 
-    it('finds the subdomain cid in an encoded query param', () => {
-        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
-        const param = `${cid}.ipfs.dweb.link`
-        const url = `https://proxy.com/?url=${param}`
-
-        assert.strictEqual(findCIDPathInURL(url), cid)
-    })
-
     it('finds the cid in the url path', () => {
         const cid = 'QmS29VtmK7Ax6TMmMwbwqtuKSGRJTLJAmHMW83qGvBBxhV'
         const url = `https://ipfs.io/ipfs/${cid}`
@@ -55,6 +47,14 @@ describe('controller', () => {
         assert.strictEqual(findCIDPathInURL(url), cidPath)
     })
 
+    it('finds the subdomain cid in an encoded query param', () => {
+        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
+        const param = `${cid}.ipfs.dweb.link`
+        const url = `https://proxy.com/?url=${param}`
+
+        assert.strictEqual(findCIDPathInURL(url), cid)
+    })
+
     it('finds the subdomain cidPath in an encoded query param', () => {
         const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
         const path = 'dog/cow/cat.png'
@@ -77,5 +77,11 @@ describe('controller', () => {
         const url = `https://proxy.com/?cid=${cidPath}`
 
         assert.strictEqual(findCIDPathInURL(url), cidPath)
+    })
+
+    it('returns empty string if cid not found', () => {
+        const url = 'https://example.com/hello/world.png'
+
+        assert.strictEqual(findCIDPathInURL(url), '')
     })
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,41 +1,81 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { findCIDInURL, getCidPathFromURL } from '#src/utils.js'
+import { findCIDPathInURL } from '#src/utils.js'
 
 describe('controller', () => {
-    it('should find cid in the subdomain', () => {
+    it('finds the cid in the subdomain', () => {
         const cid = 'bafybeigt4657qnz5bi2pa7tdsbiobny55hkpt5vupgnueex22tzvwxfiym'
         const url = `https://${cid}.ipfs.dweb.link`
 
-        const foundCid = findCIDInURL(url)
-        assert.strictEqual(foundCid, cid)
+        assert.strictEqual(findCIDPathInURL(url), cid)
     })
 
-    it('should find cid in the url path', () => {
-        const cid = 'QmS29VtmK7Ax6TMmMwbwqtuKSGRJTLJAmHMW83qGvBBxhV'
-        const url = `https://ipfs.io/ipfs/${cid}`
-
-        const foundCid = findCIDInURL(url)
-        assert.strictEqual(foundCid, cid)
-    })
-
-    it('should find cidPath in the subdomain', () => {
-        const cid = 'bafybeigt4657qnz5bi2pa7tdsbiobny55hkpt5vupgnueex22tzvwxfiym'
-        const path = 'hello/world.png'
+    it('finds the cidPath in the subdomain', () => {
+        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
+        const path = 'test/cat.png'
         const cidPath = `${cid}/${path}`
         const url = `https://${cid}.ipfs.dweb.link/${path}`
 
-        const foundCidPath = getCidPathFromURL(url, cid)
-        assert.strictEqual(foundCidPath, cidPath)
+        assert.strictEqual(findCIDPathInURL(url), cidPath)
     })
 
-    it('should find cidPath in the url path', () => {
-        const cid = 'QmS29VtmK7Ax6TMmMwbwqtuKSGRJTLJAmHMW83qGvBBxhV'
-        const path = 'hello/world.png'
-        const cidPath = `${cid}/${path}`
-        const url = `https://ipfs.io/ipfs/${cid}/${path}`
+    it('finds the subdomain cid in an encoded query param', () => {
+        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
+        const param = `${cid}.ipfs.dweb.link`
+        const url = `https://proxy.com/?url=${param}`
 
-        const foundCidPath = getCidPathFromURL(url, cid)
-        assert.strictEqual(foundCidPath, cidPath)
+        assert.strictEqual(findCIDPathInURL(url), cid)
+    })
+
+    it('finds the cid in the url path', () => {
+        const cid = 'QmS29VtmK7Ax6TMmMwbwqtuKSGRJTLJAmHMW83qGvBBxhV'
+        const url = `https://ipfs.io/ipfs/${cid}`
+
+        assert.strictEqual(findCIDPathInURL(url), cid)
+    })
+
+    it('finds the cidPath in the url path', () => {
+        const cidPath = 'QmS29VtmK7Ax6TMmMwbwqtuKSGRJTLJAmHMW83qGvBBxhV/cat.png'
+        const url = `https://ipfs.io/ipfs/${cidPath}`
+
+        assert.strictEqual(findCIDPathInURL(url), cidPath)
+    })
+
+    it('finds the cid in an encoded query param', () => {
+        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
+        const url = `https://proxy.com/?url=ipfs.io%2Fipfs%2F${cid}/`
+
+        assert.strictEqual(findCIDPathInURL(url), cid)
+    })
+
+    it('finds the cidPath in an encoded query param', () => {
+        const cidPath = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily/test/cat.png'
+        const url = `https://proxy.com/?url=https%3A%2F%2Fipfs.io%2Fipfs%2F${cidPath}`
+
+        assert.strictEqual(findCIDPathInURL(url), cidPath)
+    })
+
+    it('finds the subdomain cidPath in an encoded query param', () => {
+        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
+        const path = 'dog/cow/cat.png'
+        const cidPath = `${cid}/${path}`
+        const param = `${cid}.ipfs.dweb.link/${path}`
+        const url = `https://proxy.com/?url=${param}`
+
+        assert.strictEqual(findCIDPathInURL(url), cidPath)
+    })
+
+    it('finds the plain cid (no /ipfs/ prefix) in an encoded query param', () => {
+        const cid = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily'
+        const url = `https://proxy.com/?cid=${cid}`
+
+        assert.strictEqual(findCIDPathInURL(url), cid)
+    })
+
+    it('finds the plain cidPath (no /ipfs/ prefix) in an encoded query param', () => {
+        const cidPath = 'bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily/test/cat.png'
+        const url = `https://proxy.com/?cid=${cidPath}`
+
+        assert.strictEqual(findCIDPathInURL(url), cidPath)
     })
 })


### PR DESCRIPTION
Handles https://github.com/filecoin-saturn/browser-client/issues/30

CID + path detection is now 1 function instead of 2, and works in these cases:

* subdomain cid:  `bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily.ipfs.dweb.link/cat.png`
* path cid: `https://ipfs.io/ipfs/bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily/cat.png`
* query param 
  * path cid  
  `https://proxy.com/?url=ipfs.io%2Fipfs%2Fbafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily%2Fcat.png`
  * subdomain cid
    `https://proxy.com/?url=bafybeidrf56yzbkocajbloyafrebrdzsam3uj35sce2fdyo4elb6zzoily.ipfs.dweb.link%2Fcat.png`